### PR TITLE
implemented check if update is neccesary with #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ This script will pull the latest version from the teaspeak site, unpack it and b
 
 Usage: `update.sh [-h, -b]`
 
-| Option        | description                                 |
-| ------------- | ------------------------------------------- |
-| -h, --help    | display help message and exit               |
-| -b, --beta    | use the optimized beta build                |
+| Option        | description                                                        |
+| ------------- | ------------------------------------------------------------------ |
+| -h, --help    | display help message and exit                                      |
+| -b, --beta    | use the optimized beta build                                       |
+| -f, --force   | enforce the update even if the newest version is already installed |
 
 ## Dependencies
 


### PR DESCRIPTION
The script reads the current version from files (if present) and compares it with the newest version.
If both versions match the update is cancelled. Can be overwritten with the new --force parameter

closes #5 